### PR TITLE
Avoid allocation

### DIFF
--- a/mail.go
+++ b/mail.go
@@ -54,8 +54,7 @@ func (c *client) Send(email, subject, body string) error {
 	req.Header.Set("Content-Type", w.FormDataContentType())
 
 	// send request
-	client := &http.Client{}
-	resp, err := client.Do(req)
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
連続使用した時に大量のメモリ確保してしまうのを避ける為に DefaultClient を使う様にしてみました。
